### PR TITLE
Last axis sorter improvement

### DIFF
--- a/src/main/java/org/jenkinsci/plugin/matrixconfigsorter/LastAxisSorter.java
+++ b/src/main/java/org/jenkinsci/plugin/matrixconfigsorter/LastAxisSorter.java
@@ -22,10 +22,19 @@ public class LastAxisSorter extends MatrixConfigurationSorter{
         int compare=0;
         List<Axis> projectAxes = configuration1.getParent().getAxes();
         if(!projectAxes.isEmpty()){
-            Axis lastAxis = projectAxes.get(projectAxes.size() - 1);
-            List<String> valuesOfLastAxis = lastAxis.getValues();
-            compare = compare(valuesOfLastAxis.indexOf(configuration1.getCombination().get(lastAxis.getName())),valuesOfLastAxis.indexOf(configuration2.getCombination().get(lastAxis.getName())));
+            for (int i=projectAxes.size() - 1; i >= 0; i--) {
+                Axis lastAxis = projectAxes.get(i);
+                List<String> valuesOfLastAxis = lastAxis.getValues();
+                int index1 = valuesOfLastAxis.indexOf(configuration1.getCombination().get(lastAxis));
+                int index2 = valuesOfLastAxis.indexOf(configuration2.getCombination().get(lastAxis));
+                compare = compare(index1, index2);
+
+                if (compare != 0) {
+                    return compare;
+                }
+            }
         }
+
         if(compare==0){
             compare= configuration1.getDisplayName().compareTo(configuration2.getDisplayName());
         }


### PR DESCRIPTION
Currently last axis sorter orders builds by last axis and then it
fallback to default algorithm which mean it compare lexicographically.
After this patch it will sort by other axis (in reverse order), which
also means that it will keep axis values order.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
